### PR TITLE
DTSPO-11430 -  Remove logic that checks if cluster is already running

### DIFF
--- a/scripts/aks-auto-start.sh
+++ b/scripts/aks-auto-start.sh
@@ -14,10 +14,6 @@ jq -c '.[]' <<< $SUBSCRIPTIONS | while read subscription; do
         RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $cluster)
         NAME=$(jq -r '.name' <<< $cluster)
 
-        if [[ "$(az aks show --name  $NAME -g $RESOURCE_GROUP | jq -r .powerState.code)" == "Running" ]]; then
-            echo "Ignoring as cluster $NAME (rg:$RESOURCE_GROUP) is already in Running State"
-            continue
-        fi
         echo "About to start cluster $NAME (rg:$RESOURCE_GROUP)"
         az aks start --resource-group $RESOURCE_GROUP --name $NAME || echo Ignoring any errors starting cluster $NAME 
         BUSINESS_AREA=$(jq -r '.tags.businessArea' <<< $cluster)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-11430


### Change description ###
Remove logic that checks if cluster is already running
Removing this as the logic is identifying that clusters are already running when they are actually powered off, resulting in the clusters not starting up at all.
Example of issue in Auto-Start Workflow Run: https://github.com/hmcts/aks-auto-shutdown/actions/runs/3928173788/jobs/6715507054


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
