### PR TITLE
Ignore renovate issue dashboard in parsing

### DIFF
--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -12,6 +12,7 @@ jobs:
   parse:
     permissions: write-all
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'renovate[bot]' }}
     steps:
       - name: Add eyes reaction
         uses: aidan-mundy/react-to-issue@v1.1.1


### PR DESCRIPTION
spam is happening in https://github.com/hmcts/aks-auto-shutdown/issues/30

untested but looks like it should work based on https://stackoverflow.com/a/71854535/4951015